### PR TITLE
[feat] Changed git methods to async.

### DIFF
--- a/Assets/Plugins/CandyCoded.GitStatus/Scripts/CustomEditor/Git.cs
+++ b/Assets/Plugins/CandyCoded.GitStatus/Scripts/CustomEditor/Git.cs
@@ -3,6 +3,7 @@
 #if UNITY_EDITOR
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Debug = UnityEngine.Debug;
 
 namespace CandyCoded.GitStatus
@@ -17,10 +18,10 @@ namespace CandyCoded.GitStatus
         public static string GitPath => "/usr/local/bin/git";
 #endif
 
-        public static Process GenerateProcess(string path, string arguments)
+        public static Task<Process> GenerateProcess(string path, string arguments)
         {
 
-            return Process.Start(new ProcessStartInfo
+            return Task.Run(() => Process.Start(new ProcessStartInfo
             {
                 FileName = path,
                 Arguments = arguments,
@@ -28,23 +29,23 @@ namespace CandyCoded.GitStatus
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true
-            });
+            }));
 
         }
 
-        public static string Branch()
+        public static async Task<string> Branch()
         {
 
-            var process = GenerateProcess(GitPath, "rev-parse --abbrev-ref HEAD");
+            var process = await GenerateProcess(GitPath, "rev-parse --abbrev-ref HEAD");
 
             return process?.StandardOutput.ReadLine();
 
         }
 
-        public static string[] Branches()
+        public static async Task<string[]> Branches()
         {
 
-            var process = GenerateProcess(GitPath, "for-each-ref --format='%(refname:short)' refs/heads");
+            var process = await GenerateProcess(GitPath, "for-each-ref --format='%(refname:short)' refs/heads");
 
             var branches = new List<string>();
 
@@ -66,10 +67,10 @@ namespace CandyCoded.GitStatus
 
         }
 
-        public static string[] ChangedFiles()
+        public static async Task<string[]> ChangedFiles()
         {
 
-            var process = GenerateProcess(GitPath, "status --short --untracked-files=no --porcelain");
+            var process = await GenerateProcess(GitPath, "status --short --untracked-files=no --porcelain");
 
             var changes = new List<string>();
 
@@ -84,10 +85,10 @@ namespace CandyCoded.GitStatus
 
         }
 
-        public static string[] UntrackedFiles()
+        public static async Task<string[]> UntrackedFiles()
         {
 
-            var process = GenerateProcess(GitPath, "ls-files --others --exclude-standard");
+            var process = await GenerateProcess(GitPath, "ls-files --others --exclude-standard");
 
             var changes = new List<string>();
 
@@ -102,10 +103,10 @@ namespace CandyCoded.GitStatus
 
         }
 
-        public static void DiscardChanges(string path)
+        public static async Task DiscardChanges(string path)
         {
 
-            var process = GenerateProcess(GitPath, $@"checkout ""{path}""");
+            var process = await GenerateProcess(GitPath, $@"checkout ""{path}""");
 
             if (process?.StandardError.ReadLine() is string line && line.StartsWith("error: pathspec"))
             {

--- a/Assets/Plugins/CandyCoded.GitStatus/Scripts/CustomEditor/GitMenuItems.cs
+++ b/Assets/Plugins/CandyCoded.GitStatus/Scripts/CustomEditor/GitMenuItems.cs
@@ -3,6 +3,7 @@
 #if UNITY_EDITOR
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using UnityEditor;
 
 namespace CandyCoded.GitStatus
@@ -22,10 +23,10 @@ namespace CandyCoded.GitStatus
 
         [MenuItem("Git/Discard Changes", false, PRIORITY)]
         [MenuItem("Assets/Discard Changes", false, PRIORITY)]
-        private static void DiscardChanges()
+        private static async void DiscardChanges()
         {
 
-            Git.DiscardChanges(GetSelectedPath());
+            await Git.DiscardChanges(GetSelectedPath());
 
         }
 
@@ -40,7 +41,7 @@ namespace CandyCoded.GitStatus
 
         [MenuItem("Git/Discard All Changes", false, PRIORITY)]
         [MenuItem("Assets/Discard All Changes", false, PRIORITY)]
-        private static void DiscardAllChanges()
+        private static async void DiscardAllChanges()
         {
 
             if (EditorUtility.DisplayDialog(
@@ -50,7 +51,7 @@ namespace CandyCoded.GitStatus
                 "Cancel"))
             {
 
-                Git.DiscardChanges(GetSelectedPath());
+                await Git.DiscardChanges(GetSelectedPath());
 
             }
 

--- a/Assets/Plugins/CandyCoded.GitStatus/Scripts/CustomEditor/GitStatus.cs
+++ b/Assets/Plugins/CandyCoded.GitStatus/Scripts/CustomEditor/GitStatus.cs
@@ -2,6 +2,7 @@
 
 #if UNITY_EDITOR
 using System;
+using System.Threading.Tasks;
 using UnityEditor;
 
 namespace CandyCoded.GitStatus
@@ -34,13 +35,17 @@ namespace CandyCoded.GitStatus
         public static void Update()
         {
 
-            branch = Git.Branch();
+            Task.Run(UpdateAsync);
 
-            branches = Git.Branches();
+        }
 
-            changedFiles = Git.ChangedFiles();
+        public static async void UpdateAsync()
+        {
 
-            untrackedFiles = Git.UntrackedFiles();
+            branch = await Git.Branch();
+            branches = await Git.Branches();
+            changedFiles = await Git.ChangedFiles();
+            untrackedFiles = await Git.UntrackedFiles();
 
             lastUpdated = DateTime.Now;
 


### PR DESCRIPTION
This feature will prevent locking the Unity editor when a git status update is being performed due to a file change or the refresh button being clicked.